### PR TITLE
Tests for hard and symbolic links

### DIFF
--- a/libarchive.cabal
+++ b/libarchive.cabal
@@ -92,7 +92,9 @@ test-suite libarchive-test
         hspec -any,
         bytestring -any,
         directory >=1.2.5.0,
-        filepath -any
+        filepath -any,
+        temporary -any,
+        mtl >=2.2.2
 
     if impl(ghc >=8.4)
         ghc-options: -Wmissing-export-lists

--- a/src/Codec/Archive/Types.hs
+++ b/src/Codec/Archive/Types.hs
@@ -41,6 +41,7 @@ data EntryContent = NormalFile !BS.ByteString
                   | Directory
                   | Symlink !FilePath
                   | Hardlink !FilePath
+    deriving (Eq)
 
 data Entry = Entry { filepath    :: !FilePath
                    , content     :: !EntryContent
@@ -48,12 +49,14 @@ data Entry = Entry { filepath    :: !FilePath
                    , ownership   :: !Ownership
                    , time        :: !(Maybe ModTime)
                    }
+    deriving (Eq)
 
 data Ownership = Ownership { userName  :: !(Maybe String)
                            , groupName :: !(Maybe String)
                            , ownerId   :: !Id
                            , groupId   :: !Id
                            }
+    deriving (Eq, Show)
 
 type Permissions = CMode
 type ModTime = (CTime, CLong)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,18 +1,49 @@
+{-# LANGUAGE LambdaCase, OverloadedStrings #-}
 module Main ( main ) where
 
 import           Codec.Archive
+import qualified Data.ByteString      as BS
 import qualified Data.ByteString.Lazy as BSL
 import           Data.Either          (isRight)
 import           Data.Foldable        (traverse_)
 import           System.Directory     (doesDirectoryExist, listDirectory)
 import           System.FilePath      ((</>))
+import           Data.List            (intersperse)
 import           Test.Hspec
+
+
+newtype TestEntries = TestEntries [Entry]
+    deriving (Eq)
+
+instance Show (TestEntries) where
+    showsPrec _ (TestEntries entries) = ("(TestEntries [" ++) . joinBy (", "++) (map showsEntry entries) . ("])" ++) where
+        showsEntry entry = ("Entry " ++) .
+            ("{filepath=" ++) . shows (filepath entry) .
+            (", content=" ++) . showsContent (content entry) .
+            (", permissions=" ++) . shows (permissions entry) .
+            (", ownership=" ++) . shows (ownership entry) .
+            (", time=" ++) . shows (time entry) .
+            ("}" ++)
+        showsContent = \case
+            NormalFile bytes -> ("(NormalFile $ " ++) . shows (BS.take 10 bytes) . (" <> undefined)" ++)
+            Directory -> ("Directory" ++)
+            Symlink target -> ("(Symlink " ++) . shows target . (')':)
+            Hardlink target -> ("(Hardlink " ++) . shows target . (')':)
+        joinBy :: ShowS -> [ShowS] -> ShowS
+        joinBy sep = foldr (.) id . intersperse sep
 
 roundtrip :: FilePath -> IO (Either ArchiveResult BSL.ByteString)
 roundtrip = fmap (fmap entriesToBSL . readArchiveBSL) . BSL.readFile
 
-testFp :: FilePath -> Spec
-testFp fp = parallel $ it ("sucessfully packs/unpacks itself (" ++ fp ++ ")") $
+itPacksUnpacks :: HasCallStack => [Entry] -> Spec
+itPacksUnpacks entries = it "packs/unpacks successfully without loss" $ do
+        (TestEntries <$> unpacked) `shouldBe` (Right $ TestEntries entries)
+    where
+        packed = entriesToBSL entries
+        unpacked = readArchiveBSL packed
+
+testFp :: HasCallStack => FilePath -> Spec
+testFp fp = parallel $ it ("sucessfully unpacks/packs (" ++ fp ++ ")") $
     roundtrip fp >>= (`shouldSatisfy` isRight)
 
 main :: IO ()
@@ -20,5 +51,28 @@ main = do
     dir <- doesDirectoryExist "test/data"
     tarballs <- if dir then listDirectory "test/data" else pure []
     hspec $
-        describe "roundtrip" $ traverse_ testFp
-            (("test/data" </>) <$> tarballs)
+        describe "roundtrip" $ do
+            traverse_ testFp (("test/data" </>) <$> tarballs)
+            context "with symlinks" . itPacksUnpacks $
+                [ simpleFile "a.txt" (NormalFile "referenced")
+                , simpleFile "b.txt" (Symlink "a.txt")
+                ]
+            context "with hardlinks" . itPacksUnpacks $
+                [ simpleFile "a.txt" (NormalFile "shared")
+                , simpleFile "b.txt" (Hardlink "a.txt")
+                ]
+            context "withforward referenced hardlinks" . itPacksUnpacks $
+                [ simpleFile "b.txt" (Hardlink "a.txt")
+                , simpleFile "a.txt" (NormalFile "shared")
+                ]
+            xcontext "having entry without ownership" . itPacksUnpacks $
+                [ stripOwnership (simpleFile "a.txt" (NormalFile "text")) ]
+            xcontext "having entry without timestamp" . itPacksUnpacks $
+                [ stripTime (simpleFile "a.txt" (NormalFile "text")) ]
+
+simpleFile :: FilePath -> EntryContent -> Entry
+simpleFile name what = Entry name what standardPermissions (Ownership (Just "root") (Just "root")  0 0) (Just (0,0))
+
+stripOwnership, stripTime :: Entry -> Entry
+stripOwnership entry = entry { ownership = Ownership Nothing Nothing 0 0 }
+stripTime entry = entry { time = Nothing }


### PR DESCRIPTION
These changes are triggered investigation when for some TAR files this library doesn't produce hard links (files completely missing) for some reason. ~~Though I still didn't reached the [root cause (in version 1.0.5.1)](https://github.com/libarchive/libarchive/issues/1254),~~ I found some ~~other~~ interesting moments.

This exposes ~~(so far)~~:
- Skipping hard links in `unpackArchive` when created with archive created with CLI `bsdtar`/`tar` and loaded with this library. See #4 .
- Either `packFiles` doesn't detect symbolic and hard links on filesystem, or unpacking doesn't create them.
- `Nothing` values for `Ownership` and timestamp in `Entry` doesn't look to have real representation in archive and results in empty user/group and `(0, 0)` timestamp.