### PR TITLE
Declare Cabal dep for custom setup

### DIFF
--- a/libarchive.cabal
+++ b/libarchive.cabal
@@ -25,6 +25,7 @@ source-repository head
 custom-setup
     setup-depends:
         base -any,
+        Cabal -any,
         chs-cabal -any
 
 flag cross


### PR DESCRIPTION
When build as part of Stack it seems like Cabal package might be hidden
even from custom build. Results in error:

```
    [1 of 2] Compiling Main             ( /tmp/ws/libarchive/Setup.hs, /tmp/ws/libarchive/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/setup/Main.o )
    [2 of 2] Compiling StackSetupShim   ( /.private/nikolay/.stack/setup-exe-src/setup-shim-mPHDZzAJ.hs, /tmp/ws/libarchive/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/setup/StackSetupShim.o )
    
    /.private/nikolay/.stack/setup-exe-src/setup-shim-mPHDZzAJ.hs:3:1: error:
        Could not load module ‘Distribution.PackageDescription’
        It is a member of the hidden package ‘Cabal-3.0.0.0’.
        You can run ‘:set -package Cabal’ to expose it.
        (Note: this unloads all the modules in the current scope.)
        It is a member of the hidden package ‘Cabal-2.4.0.1’.
        You can run ‘:set -package Cabal’ to expose it.
        (Note: this unloads all the modules in the current scope.)
        Use -v to see a list of the files searched for.
      |
    3 | import Distribution.PackageDescription (PackageDescription, emptyHookedBuildInfo)
      | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    
```

Fixes vmchale/libarchive#1