### PR TITLE
Add documentation to ModTime

### DIFF
--- a/src/Codec/Archive/Types.cpphs
+++ b/src/Codec/Archive/Types.cpphs
@@ -69,6 +69,8 @@ type Permissions = CUShort
 #else
 type Permissions = CMode
 #endif
+
+-- | Pair of a UNIX time stamp and a nanosecond fractional part.
 type ModTime = (CTime, CLong)
 
 -- | A user or group ID


### PR DESCRIPTION
I deduced this semantics for `ModTime` in the following way:

- Observe that `Entry` is consumed by `archiveEntryAdd` here: https://github.com/vmchale/libarchive/blob/dcc6aaa01bc4f2edf4c2b2db687e20e60a54c4b0/src/Codec/Archive/Internal/Pack.hs#L252-L260
- Observe that the `ModTime` is comsumed using `setTime` here: https://github.com/vmchale/libarchive/blob/dcc6aaa01bc4f2edf4c2b2db687e20e60a54c4b0/src/Codec/Archive/Internal/Pack.hs#L88-L89
- `archiveEntrySetMtime` is generated from `archive_entry_set_mtime` from `libarchive`: https://github.com/vmchale/libarchive/blob/dcc6aaa01bc4f2edf4c2b2db687e20e60a54c4b0/src/Codec/Archive/Foreign/ArchiveEntry.chs#L344
- `archive_entry_set_mtime` takes arguments `time_t sec, long nanosec` in C (from `archive_entry_time(3)`), with no further documentation there; `time_t` in C implies a unix timestamp.