### PR TITLE
Cannot build on Windows with GHC 9.4

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macOS, windows]
-        builder: ['cabal 3.6.2.0 ghc 8.10.7', 'cabal 3.6.2.0 ghc 9.0.1', 'stack 2.7.3']
+        builder: ['cabal 3.6.2.0 ghc 8.10.7', 'cabal 3.6.2.0 ghc 9.0.1', 'cabal 3.6.2.0 ghc 9.2.8', 'cabal 3.6.2.0 ghc 9.4.7', 'stack 2.7.3']
 
         include:
           - os: windows

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macOS, windows]
-        builder: ['cabal 3.6.2.0 ghc 8.10.7', 'cabal 3.6.2.0 ghc 9.0.1', 'cabal 3.6.2.0 ghc 9.2.8', 'cabal 3.6.2.0 ghc 9.4.7', 'stack 2.7.3']
+        builder: ['cabal 3.10.2.1 ghc 8.10.7', 'cabal 3.10.2.1 ghc 9.0.1', 'cabal 3.10.2.1 ghc 9.2.8', 'cabal 3.10.2.1 ghc 9.4.7', 'stack 2.7.3']
 
         include:
           - os: windows


### PR DESCRIPTION
As witnessed by CI at https://github.com/Bodigrim/libarchive/actions/runs/6605253232/job/17940229969#step:14:124:
```
Configuring libarchive-3.0.4.2...
Preprocessing library for libarchive-3.0.4.2..
c2hs.exe: C header contains errors:

Error: p/ghc/9.4.7/mingw/lib/clang/14.0.6/include/ia32intrin.h:222: (column 29) [ERROR]  >>> Syntax error !
  The symbol `unsigned' does not fit here.

Error: Process completed with exit code 1.
```

This is presumably because starting from 9.4 GHC uses clang instead of gcc on Windows, thus different headers, which `c2hs` is incapable to deal with. 

One might hit this issue by building `ghcup` on Windows with GHC 9.4. CC @hasufell. 

I assume that this actually a general issue with `c2hs`. CC @deech.